### PR TITLE
Add null for typed properties

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,14 +9,14 @@ env:
 
 jobs:
     cs:
-        name: "Codestyle check on PHP 8.0"
+        name: "Codestyle check on PHP 8.1"
         runs-on: "ubuntu-latest"
 
         steps:
             - name: "Set up PHP"
               uses: "shivammathur/setup-php@v2"
               with:
-                  php-version: "8.0"
+                  php-version: "8.1"
                   tools: "composer:v2"
 
             - name: "Checkout code"
@@ -39,7 +39,6 @@ jobs:
                     - "lowest"
                     - "highest"
                 php-version:
-                    - "8.0"
                     - "8.1"
                     - "8.2"
                 experimental:
@@ -79,7 +78,7 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - "8.0"
+                    - "8.1"
 
         steps:
             - name: "Set up PHP"

--- a/src/Renderer/Php74Renderer.php
+++ b/src/Renderer/Php74Renderer.php
@@ -17,6 +17,13 @@ class Php74Renderer extends Php7Renderer
 	{
 		$ret = [];
 
+		if ($variable->getType()->isNullable() &&
+			$variable->getInitializedValue() === PhpVariable::NO_VALUE &&
+			$variable->getType()->getTypeHint()
+		) {
+			$variable->setInitializedValue(null);
+		}
+
 		$comment = $variable->getComment();
 		if ($comment) {
 			$ret = FlattenSource::applySourceOn($this->renderComment($comment), $ret);

--- a/src/Renderer/Php8Renderer.php
+++ b/src/Renderer/Php8Renderer.php
@@ -45,8 +45,13 @@ class Php8Renderer extends Php74Renderer
 			return null;
 		}
 
-		if ($variable->getType()->getType() === 'mixed') {
+
+		$type = $variable->getType();
+		if ($type->getType() === 'mixed') {
 			$variable->getComment()?->removeVar();
+		}
+		if ($type->isUnion() && $type->isNullable() && $variable->getInitializedValue() === PhpVariable::NO_VALUE) {
+			$variable->setInitializedValue(null);
 		}
 
 		return parent::renderVariable($variable, $parent);

--- a/tests/Renderer/PhpVariableTest.php
+++ b/tests/Renderer/PhpVariableTest.php
@@ -243,7 +243,7 @@ final class PhpVariableTest extends TestCase
 
 		$this->assertSame([
 			'/** @var string[]|null */',
-			'protected ?array $test;',
+			'protected ?array $test = null;',
 		], $renderer->renderVariable($variable));
 	}
 

--- a/tests/Renderer/resources/PhpClassTest.testClassRenderedWithPhp74.result
+++ b/tests/Renderer/resources/PhpClassTest.testClassRenderedWithPhp74.result
@@ -4,7 +4,7 @@ class TestClass extends DateTimeImmutable implements JsonSerializable
 	protected $param1;
 	/** @var string|int|null */
 	public $var1;
-	private ?int $param2;
+	private ?int $param2 = null;
 
 	/**
 	 * @param string|int $param1

--- a/tests/Renderer/resources/PhpClassTest.testClassRenderedWithPhp8.result
+++ b/tests/Renderer/resources/PhpClassTest.testClassRenderedWithPhp8.result
@@ -1,6 +1,6 @@
 class TestClass extends DateTimeImmutable implements JsonSerializable
 {
-	public null|string|int $var1;
+	public null|string|int $var1 = null;
 
 	public function __construct(
 		protected string|int $param1,

--- a/tests/Renderer/resources/PhpClassTest.testClassRenderedWithPhp81.result
+++ b/tests/Renderer/resources/PhpClassTest.testClassRenderedWithPhp81.result
@@ -1,6 +1,6 @@
 class TestClass extends DateTimeImmutable implements JsonSerializable
 {
-	public null|string|int $var1;
+	public null|string|int $var1 = null;
 
 	public function __construct(
 		protected readonly string|int $param1,

--- a/tests/Renderer/resources/PhpClassTest.testClassRenderedWithPhp82.result
+++ b/tests/Renderer/resources/PhpClassTest.testClassRenderedWithPhp82.result
@@ -1,6 +1,6 @@
 class TestClass extends DateTimeImmutable implements JsonSerializable
 {
-	public null|string|int $var1;
+	public null|string|int $var1 = null;
 
 	public function __construct(
 		protected readonly string|int $param1,


### PR DESCRIPTION
We do this to avoid `cannot access uninitialized property`

We only do this for properties that have been type hinted 
So in 7.4 we don't add null to union types but we do in 8.0

And we only do this for none promoted properties 